### PR TITLE
fix: incorrect url redirect preventing of 'web.wechat.com'

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ let createWindow = () => {
   browserWindow.loadURL("https://wx.qq.com/");
 
   browserWindow.webContents.on('will-navigate', (ev, url) => {
-    if (/.*wx.*\.qq\.com.*/.test(url)) return;
+    if (/(.*wx.*\.qq\.com.*)|(web.wechat.com)/.test(url)) return;
     // Prevent navigation off the site.
     ev.preventDefault();
   });


### PR DESCRIPTION
Fix an bug while login(possiblely on OS X).
Regex checking in event callback of `will-navigate` missed a domain 'web.wechat.com'.