### PR TITLE
Ignore npm-debug.log*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 /dist
-npm-debug.log
+npm-debug.log*
 .idea
 
 # Dependency directories


### PR DESCRIPTION
Occasionally logs like `npm-debug.log.0102030405` are generated. Ignore them.

btw, GitHub provides a [Node.gitignore](https://github.com/github/gitignore/blob/master/Node.gitignore).