### PR TITLE
Changed the shortcut of menu item 'Hide Others'.

### DIFF
--- a/src/handler/menu.js
+++ b/src/handler/menu.js
@@ -42,7 +42,7 @@ class MenuHandler {
           },
           {
             label: 'Hide Others',
-            accelerator: 'Command+Shift+H',
+            accelerator: 'Command+Alt+H',
             selector: 'hideOtherApplications:'
           },
           {


### PR DESCRIPTION
The default shortcut to hide other applications in OS X is Command+Alt+H, instead of Command+Shift+H. 

As I mentioned in [Issue #126](https://github.com/geeeeeeeeek/electronic-wechat/issues/126)