### PR TITLE
Fix issues link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First of all, thanks for contributing to this project. It would be appreciated i
 
 ## Issues
 
-- Check if your issue is already [there](https://github.com/geeeeeeeeek/electronic-wechat). 
+- Check if your issue is already [there](https://github.com/geeeeeeeeek/electronic-wechat/issues). 
 
 - Check if your issue is `Electronic WeChat` related rather than upstream related.
 


### PR DESCRIPTION
It's meant to be taking people to Issues page directly. Guess I don't have to open an issue to make the change :)
The change in last line is some GitHub online editor magic.