### PR TITLE
Some bug fixes, add keyboard control to mention_menu, and some css changes

### DIFF
--- a/src/inject/css.js
+++ b/src/inject/css.js
@@ -62,7 +62,7 @@ CSSInjector.commonCSS = `
       display: none !important
     }
     /* Group mention: user selection box */
-    div#userSelectionBox select option:hover {
+    div#userSelectionBox select option:hover, div#userSelectionBox select option.hovered{
       background: #eeeeee;
     }
     div#userSelectionBox select option {
@@ -80,15 +80,19 @@ CSSInjector.commonCSS = `
       border: none;
       outline: none;
       height: inherit;
+      display: table;
     }
     div#userSelectionBox {
       box-shadow: 1px 1px 10px #ababab;
       background: #fff;
       display: none;
       position: fixed;
+      overflow-x:hidden;
+      overflow-y:auto;
       bottom: ${Common.MENTION_MENU_INITIAL_Y}px;
       left: ${Common.MENTION_MENU_INITIAL_X}px;
     }
+
     span.measure_text {
       padding-left: 20px;
       outline: 0;
@@ -110,5 +114,13 @@ CSSInjector.osxCSS = `
       width: 172px !important;
     }
 `;
+
+
+CSSInjector.enlargeEmoji = `
+    .message .custom_emoji{
+        width: 120px !important;
+        height: auto !important;
+    }
+`
 
 module.exports = CSSInjector;

--- a/src/inject/mention_menu.js
+++ b/src/inject/mention_menu.js
@@ -27,11 +27,20 @@ class MentionMenu {
     });
     $box.append($select);
     $('body').append($box);
+    MentionMenu.hideMenuWhenBlur();
   }
+
+
 
   static inject($event) {
     const $editArea = $($event.currentTarget);
     const $box = $('#userSelectionBox');
+
+    if($box.css('display') != 'none' && /^(40|38|32|27)$/.test($event.keyCode)){
+
+      MentionMenu.nevigateMenu($event,$box);
+      return;
+    }
 
     let $probe = $('<span id="probe"/>');
     $editArea.append($probe);
@@ -128,6 +137,59 @@ class MentionMenu {
     $option.html(displayName);
 
     return $option;
+  }
+
+  static hideMenuWhenBlur() {
+
+    $('#editArea').scope()['editAreaBlur'] = function() {
+      var oriFun = $('#editArea').scope()['editAreaBlur'];
+      return ($event) => {
+
+        oriFun.apply(this, $event);
+        if ($('#userSelectionBox').css('display') != 'none' && !$('#userSelectionBox').is(":hover")) {
+          $('#userSelectionBox').hide();
+        }
+      }
+    }()
+  }
+
+  static nevigateMenu($event, $box) {
+    switch ($event.keyCode) {
+
+      case 32:
+        if ($($box.find('.hovered')).length || $($box.find('option:hover')).length) {
+          var val = $($box.find('.hovered')).length ? $($box.find('.hovered')).val() : $($('#userSelectionBox').find('option:hover')).val();
+          $('#userSelectionBox > select').val(val).trigger('change');
+        }
+        break;
+
+      case 40:
+        $event.preventDefault();
+        var $currenSelc = $box.find('.hovered');
+        $currenSelc.removeClass('hovered');
+        if ($currenSelc.next().length) {
+          $currenSelc.next().addClass('hovered');
+        } else {
+          $($box.find('option')[0]).addClass('hovered');
+        }
+        break;
+
+      case 38:
+        $event.preventDefault();
+        var $currenSelc = $box.find('.hovered');
+        $currenSelc.removeClass('hovered');
+        if ($currenSelc.prev().length) {
+          $currenSelc.prev().addClass('hovered');
+        } else {
+          $box.find('option').last().addClass('hovered');
+        }
+        break;
+
+      case 27:
+        $box.hide();
+        $('#userSelectionBox > select').val('');
+        break;
+    }
   }
 }
 

--- a/src/inject/preload.js
+++ b/src/inject/preload.js
@@ -50,21 +50,23 @@ class Injector {
   }
 
   initInjectBundle() {
-    let initModules = ()=> {
-      if (!window.$) {
-        return setTimeout(initModules, 3000);
-      }
+    var self = this;
+    setTimeout(function(){
 
-      MentionMenu.init();
-      BadgeCount.init();
-    };
+        if (!window.$) {
 
-    window.onload = () => {
-      initModules();
-      window.addEventListener('online', ()=> {
-        ipcRenderer.send('reload', true);
-      });
-    };
+          self.initInjectBundle();
+
+        }else{
+
+          window.addEventListener('online', ()=> {
+                ipcRenderer.send('reload', true);
+          });
+          MentionMenu.init();
+          BadgeCount.init();
+        }
+
+    },1000)
   }
 
   transformResponse(value, constants) {


### PR DESCRIPTION
-bug fix

window.onload 的 trigger 时间 大约要~10s 所以 MentionMenu 通常要等待10s后才会被append到body上 可能是我人在国外的关系 所以有些css js load得比较慢 希望国内的同学帮忙测试一下 我把window.onload删除了。 现在 append 之前只判断 window.$ != null

mention_menu 会一直存在 就算你切换了联系人 我加了一个 hideMenu 的 function 挂在了 editAreaBlur 上， 只要editArea 失去 focus 那么mention_menu 就会hide()

-新加功能

现在mention_menu 能通过 ArrowUp
ArrowDown Space 和 Escape 来控制 空格可以直接选中hovered项 Escape 用来hide menu

-另外 
修改了一些 mention_menu 的 css
添加了一个 .hover 为了实现按键控制menu 
把emoji 的size 改大了一些 以前是 width:60px 现在改成了 120px 看起来好看一些

-Wishlist
如果menu_list太长 你在用ArrowDown 或者 ArrowUp 它不会自动Scroll 我有时间把这个加上去

希望有同学能帮忙测试一下