### PR TITLE
When viewport < 512px, display a compact left bar

### DIFF
--- a/src/inject/css.js
+++ b/src/inject/css.js
@@ -95,6 +95,29 @@ CSSInjector.commonCSS = `
       border: 0;
       font-size: 14px;
     }
+    @media (max-width: 512px) {
+      .panel {
+        width: 50px!important;
+        transition: width .3s;
+      }
+      .panel .header,
+      .chat_item {
+        padding: 5px!important
+      }
+      .header .info,
+      .panel .tab,
+      .search_bar,
+      .chat_item .info,
+      .chat_item .ext {
+        display: none!important
+      }
+      .nav_view {
+        top: 54px!important
+      }
+      .chat_item.active {
+        border-left: 3px solid #eee!important
+      }
+    }
   `;
 
 CSSInjector.osxCSS = `


### PR DESCRIPTION
1. only display avatar, name will not display
2. hide searchbar and the followed nav tabbar
3. when user adjust the window and viewport > 512px, left bar will display normal

![](http://ww1.sinaimg.cn/mw690/4e5d3ea7jw1f5mmc3hcs4j20ff0iiaaw.jpg)