### PR TITLE
Enable tray icon click event on Linux

### DIFF
--- a/src/windows/controllers/app_tray.js
+++ b/src/windows/controllers/app_tray.js
@@ -30,9 +30,8 @@ class AppTray {
         {label: 'Exit', click: () => app.exit(0)}
       ]);
       this.tray.setContextMenu(contextMenu);
-    } else {
-      this.tray.on('click', () => this.hideSplashAndShowWeChat());
     }
+    this.tray.on('click', () => this.hideSplashAndShowWeChat());
   }
 
   setTitle(title) {


### PR DESCRIPTION
This addresses issue #178 .

The [Electron docs](https://github.com/electron/electron/blob/master/docs/api/tray.md) says the click event only fires on Linux if using GTK indicator, so listening to the click event is not reliable. However, there is no downside to listening to the event even if it never fires. With this change, the click event does fire for me on Ubuntu 14.04 with MATE.