### PR TITLE
临时修复非官方客户端，无法登陆提示

### DIFF
--- a/src/windows/controllers/wechat.js
+++ b/src/windows/controllers/wechat.js
@@ -89,6 +89,11 @@ class WeChatWindow {
       event.preventDefault();
       shell.openExternal(new MessageHandler().handleRedirectMessage(url));
     });
+    
+    this.wechatWindow.webContents.on('will-navigate', (event, url) => {
+      if (url.endsWith('/fake')) event.preventDefault();
+    });
+    
   }
 
   loadURL(url) {


### PR DESCRIPTION
官方版本检测angular对象有没有被篡改，篡改的话就重定向到新页面。
这个方法就是劫持取消重定向。