### PR TITLE
Add two menus (with keyboard shortcuts)

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -89,6 +89,7 @@ Common.MENU = {
   view: 'View',
   reload: 'Reload This Window',
   toggleFullScreen:'Toggle Full Screen',
+  searchContacts:'Search Contacts',
   devtool: 'Toggle DevTools',
   window: 'Window',
   min: 'Minimize',

--- a/src/common.js
+++ b/src/common.js
@@ -88,6 +88,7 @@ Common.MENU = {
   selectAll: 'Select All',
   view: 'View',
   reload: 'Reload This Window',
+  toggleFullScreen:'Toggle Full Screen',
   devtool: 'Toggle DevTools',
   window: 'Window',
   min: 'Minimize',

--- a/src/common_cn.js
+++ b/src/common_cn.js
@@ -81,6 +81,7 @@ Common.MENU = {
   view: '视图',
   reload: '重新加载当前窗口',
   toggleFullScreen:'切换全屏',
+  searchContacts:'搜索联系人',
   devtool: '开发者工具',
   window: '窗口',
   min: '最小化',

--- a/src/common_cn.js
+++ b/src/common_cn.js
@@ -80,6 +80,7 @@ Common.MENU = {
   selectAll: '选择全部',
   view: '视图',
   reload: '重新加载当前窗口',
+  toggleFullScreen:'切换全屏',
   devtool: '开发者工具',
   window: '窗口',
   min: '最小化',

--- a/src/handlers/menu.js
+++ b/src/handlers/menu.js
@@ -109,6 +109,16 @@ class MenuHandler {
             accelerator: 'Command+A',
             selector: 'selectAll:',
           },
+          {
+            type: 'separator',
+          },
+          {
+            label: Common.MENU.searchContacts,
+            accelerator: 'Command+F',
+            click: function () {
+              $('#search_bar input')[0].focus();
+            }
+          }
         ],
       },
       {
@@ -191,6 +201,16 @@ class MenuHandler {
               if (focusedWindow) {
                 focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
               }
+            }
+          },
+          {
+            type: 'separator',
+          },
+          {
+            label: Common.MENU.searchContacts,
+            accelerator: 'Ctrl+F',
+            click: function () {
+              $('#search_bar input')[0].focus();
             }
           },
           {

--- a/src/handlers/menu.js
+++ b/src/handlers/menu.js
@@ -140,6 +140,15 @@ class MenuHandler {
             selector: 'performClose:',
           },
           {
+            label: Common.MENU.toggleFullScreen,
+            accelerator: 'Ctrl+Command+F',
+            click: function (item, focusedWindow) {
+              if (focusedWindow) {
+                focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
+              }
+            }
+          },
+          {
             type: 'separator',
           },
           {
@@ -174,6 +183,15 @@ class MenuHandler {
             label: Common.MENU.reload,
             accelerator: 'Ctrl+R',
             click: () => MenuHandler._reload,
+          },
+          {
+            label: Common.MENU.toggleFullScreen,
+            accelerator: 'F11',
+            click: function (item, focusedWindow) {
+              if (focusedWindow) {
+                focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
+              }
+            }
           },
           {
             label: Common.MENU.devtool,


### PR DESCRIPTION
The two menus are:
'Search Contacts' : Let the search bar get focus, so that we don't need to click it.
'Toggle Full Screen' : No need to explain...

Both are related to a keyboard shortcut for Mac and Linux.