### PR TITLE
let menu always visible in xfce session

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "nconf": "^0.8.4",
     "pinyin": "^2.8.0",
     "emojione": "^2.2.7",
-    "electron-localshortcut": "1.1.0"
+    "electron-localshortcut": "1.1.0",
+    "is-xfce": "^1.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/src/windows/controllers/wechat.js
+++ b/src/windows/controllers/wechat.js
@@ -70,7 +70,6 @@ class WeChatWindow {
 
     /* menu is always visible on xfce session */
     isXfce().then(data => {
-      console.log(data);
       if(data) {
         this.wechatWindow.setMenuBarVisibility(true);
         this.wechatWindow.setAutoHideMenuBar(false);

--- a/src/windows/controllers/wechat.js
+++ b/src/windows/controllers/wechat.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const path = require('path');
+const isXfce = require('is-xfce');
 const { app, shell, BrowserWindow } = require('electron');
 const electronLocalShortcut = require('electron-localshortcut');
 
@@ -65,6 +66,15 @@ class WeChatWindow {
         webSecurity: false,
         preload: path.join(__dirname, '../../inject/preload.js'),
       },
+    });
+
+    /* menu is always visible on xfce session */
+    isXfce().then(data => {
+      console.log(data);
+      if(data) {
+        this.wechatWindow.setMenuBarVisibility(true);
+        this.wechatWindow.setAutoHideMenuBar(false);
+      }
     });
   }
 


### PR DESCRIPTION
最近把桌面环境从unity换成了xfce。unity的菜单都是在顶部，鼠标移动一下就可以看见。但是xfce菜单实在窗口顶端，这样的话每次都要按`Alt`键才可以看见菜单。而且默认一开始菜单不可见，这样影响可用性。现在增加一个判断是不是xfce环境的判断，然后默认菜单一直可见在xfce环境下。

不知道这个问题在其他桌面环境比如gnome，kde下有没有。

另外在code里面看到很多object最后都有一个多余的逗号，比如: `{key: "value",}`, 这个虽然没什么问题，但是IDE里面看着很不舒服，是不是可以考虑把这些多余的逗号去掉。