### PR TITLE
fix overflow problems and electron version in config page

### DIFF
--- a/src/windows/styles/settings.css
+++ b/src/windows/styles/settings.css
@@ -29,9 +29,8 @@ section {
   position: relative;
   width: 75%;
   left: 12.5%;
-  margin: 1px;
   border-bottom: 1px solid gray;
-  text-align:
+  overflow: hidden;
 }
 
 .page {
@@ -62,9 +61,9 @@ section {
   padding: 0;
   margin: 0 0 10px 0;
   border: none;
-  height: 130px;
+  height: 140px;
   width: 100%;
-  overflow: auto;
+  overflow: hidden;
   background-color: #CCC;
   box-shadow: 0px 5px 5px #CCC;
 }

--- a/src/windows/views/settings.html
+++ b/src/windows/views/settings.html
@@ -21,7 +21,7 @@
         <li>
           <h1>Electronic Wechat V2.0.0</h1></li>
         <li>
-          <h1 style="font-size:95%;">Powered by Electron V1.4.7</h1></li>
+          <h1 style="font-size:95%;">Powered by Electron V<span id="top-title-electron-ver">process.versions.electron</span></h1></li>
       </ul>
     </div>
   </div>
@@ -110,6 +110,7 @@
       return document.getElementById(id);
     }
 
+    $('top-title-electron-ver').innerText = process.versions.electron;
     setConfig();
     setListeners()
 


### PR DESCRIPTION
before:
![image](https://cloud.githubusercontent.com/assets/13914967/25960511/c8371044-363c-11e7-9129-b82ddf785668.png)

after:
![image](https://cloud.githubusercontent.com/assets/13914967/25960480/ad0a74a0-363c-11e7-9053-c1dbe2e56de0.png)

the electron version is provided by `process.versions.electron`, not hardcoded